### PR TITLE
Database script kjøres ikke på windows

### DIFF
--- a/docker/local/postgres/initdb.sh
+++ b/docker/local/postgres/initdb.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+
 set -e
 
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL


### PR DESCRIPTION
På Windows 10 vil ikke scriptet kjøres dersom referansen til script typen er tilstede. Altså at filen starter med #!/bin/bash. 