### PR TITLE
Ny issuer av jwt tokens

### DIFF
--- a/deploy/dev.yaml
+++ b/deploy/dev.yaml
@@ -58,12 +58,6 @@ spec:
       value: sporenstreks
     - name: VAULT_MOUNTPATH
       value: postgresql/preprod-fss/
-    - name: OIDC_ISSUER_NAME
-      value: loginservice-test
-    - name: OIDC_DISCOVERY_URL
-      value: "https://navtestb2c.b2clogin.com/navtestb2c.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_idporten_ver1"
-    - name: OIDC_ACCEPTED_AUDIENCE
-      value: 0090b6e1-ffcc-4c37-bc21-049f7d1f0fe5
     - name: ALTINN_SERVICE_OWNER_GW_URL
       value: https://api-gw-q1.adeo.no/ekstern/altinn/api/serviceowner
     - name: SECURITYTOKENSERVICE_URL_REST

--- a/deploy/dev.yaml
+++ b/deploy/dev.yaml
@@ -59,7 +59,7 @@ spec:
     - name: OIDC_ISSUER_NAME
       value: "https://navtestb2c.b2clogin.com/d38f25aa-eab8-4c50-9f28-ebf92c1256f2/v2.0/"
     - name: OIDC_DISCOVERY_URL
-      value: "https://login.microsoftonline.com/NAVtestB2C.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_idporten_ver1"
+      value: "https://navtestb2c.b2clogin.com/navtestb2c.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_idporten_ver1"
     - name: OIDC_ACCEPTED_AUDIENCE
       value: 0090b6e1-ffcc-4c37-bc21-049f7d1f0fe5
     - name: ALTINN_SERVICE_OWNER_GW_URL

--- a/deploy/dev.yaml
+++ b/deploy/dev.yaml
@@ -57,7 +57,7 @@ spec:
     - name: VAULT_MOUNTPATH
       value: postgresql/preprod-fss/
     - name: OIDC_ISSUER_NAME
-      value: aadb2c
+      value: "https://navtestb2c.b2clogin.com/d38f25aa-eab8-4c50-9f28-ebf92c1256f2/v2.0/"
     - name: OIDC_DISCOVERY_URL
       value: "https://login.microsoftonline.com/NAVtestB2C.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_idporten_ver1"
     - name: OIDC_ACCEPTED_AUDIENCE

--- a/deploy/dev.yaml
+++ b/deploy/dev.yaml
@@ -45,6 +45,8 @@ spec:
         kvPath: /serviceuser/data/dev/srvsporenstreks
   webproxy: true
   leaderElection: true
+  envFrom:
+    - configmap: loginservice-idporten # tilgjengeliggjør LOGINSERVICE_IDPORTEN_DISCOVERY_URL og LOGINSERVICE_IDPORTEN_AUDIENCE
   env:
     - name: KOIN_PROFILE
       value: PREPROD
@@ -57,7 +59,7 @@ spec:
     - name: VAULT_MOUNTPATH
       value: postgresql/preprod-fss/
     - name: OIDC_ISSUER_NAME
-      value: "https://navtestb2c.b2clogin.com/d38f25aa-eab8-4c50-9f28-ebf92c1256f2/v2.0/"
+      value: loginservice-test
     - name: OIDC_DISCOVERY_URL
       value: "https://navtestb2c.b2clogin.com/navtestb2c.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_idporten_ver1"
     - name: OIDC_ACCEPTED_AUDIENCE

--- a/deploy/prod.yaml
+++ b/deploy/prod.yaml
@@ -59,16 +59,6 @@ spec:
       value: sporenstreks
     - name: VAULT_MOUNTPATH
       value: postgresql/prod-fss/
-    - name: OIDC_DISCOVERY_URL
-      value: https://login.microsoftonline.com/navnob2c.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_idporten
-    - name: OIDC_DISCOVERY_URL_NEW
-      value: https://navnob2c.b2clogin.com/navnob2c.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_idporten
-    - name: OIDC_ACCEPTED_AUDIENCE
-      value: 45104d6a-f5bc-4e8c-b352-4bbfc9381f25
-    - name: OIDC_ISSUER_NAME
-      value: aadb2c
-    - name: OIDC_ISSUER_NAME_NEW
-      value: "https://navnob2c.b2clogin.com/8b7dfc8b-b52e-4741-bde4-d83ea366f94f/v2.0/"
     - name: ALTINN_SERVICE_OWNER_GW_URL
       value: https://api-gw.adeo.no/ekstern/altinn/api/serviceowner
     - name: SECURITYTOKENSERVICE_URL_REST

--- a/deploy/prod.yaml
+++ b/deploy/prod.yaml
@@ -58,10 +58,14 @@ spec:
       value: postgresql/prod-fss/
     - name: OIDC_DISCOVERY_URL
       value: https://login.microsoftonline.com/navnob2c.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_idporten
+    - name: OIDC_DISCOVERY_URL_NEW
+      value: https://navnob2c.b2clogin.com/navnob2c.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_idporten
     - name: OIDC_ACCEPTED_AUDIENCE
       value: 45104d6a-f5bc-4e8c-b352-4bbfc9381f25
     - name: OIDC_ISSUER_NAME
       value: aadb2c
+    - name: OIDC_ISSUER_NAME_NEW
+      value: "https://navnob2c.b2clogin.com/8b7dfc8b-b52e-4741-bde4-d83ea366f94f/v2.0/"
     - name: ALTINN_SERVICE_OWNER_GW_URL
       value: https://api-gw.adeo.no/ekstern/altinn/api/serviceowner
     - name: SECURITYTOKENSERVICE_URL_REST

--- a/deploy/prod.yaml
+++ b/deploy/prod.yaml
@@ -45,6 +45,9 @@ spec:
         kvPath: /serviceuser/data/prod/srvsporenstreks
   webproxy: true
   leaderElection: true
+  envFrom:
+    - configmap: loginservice-idporten # tilgjengeliggjør LOGINSERVICE_IDPORTEN_DISCOVERY_URL og LOGINSERVICE_IDPORTEN_AUDIENCE
+
   env:
     - name: KOIN_PROFILE
       value: PROD

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -58,15 +58,12 @@ leader_election{
 no.nav.security.jwt {
   issuers = [
     {
-      issuer_name = iss-localhost
-      issuer_name = ${?OIDC_ISSUER_NAME}
+      issuer_name = loginservice-issuer
       discoveryurl = "http://localhost:6666/.well-known/openid-configuration"
       discoveryurl = ${?LOGINSERVICE_IDPORTEN_DISCOVERY_URL}
       accepted_audience = aud-localhost
       accepted_audience = ${?LOGINSERVICE_IDPORTEN_AUDIENCE}
-      //cookie_name = localhost-idtoken
       cookie_name = selvbetjening-idtoken
-      cookie_name = ${?COOKIE_NAME}
     }
   ]
 }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -61,9 +61,9 @@ no.nav.security.jwt {
       issuer_name = iss-localhost
       issuer_name = ${?OIDC_ISSUER_NAME}
       discoveryurl = "http://localhost:6666/.well-known/openid-configuration"
-      discoveryurl = ${?OIDC_DISCOVERY_URL}
+      discoveryurl = ${?LOGINSERVICE_IDPORTEN_DISCOVERY_URL}
       accepted_audience = aud-localhost
-      accepted_audience = ${?OIDC_ACCEPTED_AUDIENCE}
+      accepted_audience = ${?LOGINSERVICE_IDPORTEN_AUDIENCE}
       //cookie_name = localhost-idtoken
       cookie_name = selvbetjening-idtoken
       cookie_name = ${?COOKIE_NAME}


### PR DESCRIPTION
Microsoft har besluttet at login.microsoftonline.com for Azure AD B2C slutter å fungere fra og med den 4. desember.
Denne har blitt erstattet av en tilsvarende URL under b2clogin.com
Endringen medfører at URL til discovery/well-known og jwks endepunktene endrer seg i tillegg til issuer i tokenet.

Bruker det anbefalte configmapet fra nais