### PR TITLE
Legger til ny og gammel periode

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,10 @@ plugins {
     jacoco
 }
 
+application {
+    mainClass.set("no.nav.helse.sporenstreks.web.AppKt")
+}
+
 sonarqube {
     properties {
         property("sonar.projectKey", "navikt_sporenstreks")

--- a/src/main/kotlin/no/nav/helse/sporenstreks/domene/Arbeidsgiverperiode.kt
+++ b/src/main/kotlin/no/nav/helse/sporenstreks/domene/Arbeidsgiverperiode.kt
@@ -15,18 +15,18 @@ data class Arbeidsgiverperiode(
         val arbeidsgiverBetalerForDager = 3
     }
 
-    fun innenforGammelPeriode (arbeidsgiverPeriode: Arbeidsgiverperiode, now: LocalDate = LocalDate.now()) : Boolean {
+    fun innenforGammelPeriode(arbeidsgiverPeriode: Arbeidsgiverperiode, now: LocalDate = LocalDate.now()): Boolean {
         val fraDato = now.minusMonths(6)
-        val tilDato = LocalDate.of(2021,10,1)
-        return arbeidsgiverPeriode.fom.isAfter(fraDato)
-            && arbeidsgiverPeriode.tom.isBefore(tilDato)
+        val tilDato = LocalDate.of(2021, 10, 1)
+        return arbeidsgiverPeriode.fom.isAfter(fraDato) &&
+            arbeidsgiverPeriode.tom.isBefore(tilDato)
     }
 
-    fun innenforNyPeriode (arbeidsgiverPeriode: Arbeidsgiverperiode) : Boolean {
-        val fraDato = LocalDate.of(2021,11,30)
-        val tilDato = LocalDate.of(2022,7,1)
-        return arbeidsgiverPeriode.fom.isAfter(fraDato)
-            && arbeidsgiverPeriode.tom.isBefore(tilDato)
+    fun innenforNyPeriode(arbeidsgiverPeriode: Arbeidsgiverperiode): Boolean {
+        val fraDato = LocalDate.of(2021, 11, 30)
+        val tilDato = LocalDate.of(2022, 7, 1)
+        return arbeidsgiverPeriode.fom.isAfter(fraDato) &&
+            arbeidsgiverPeriode.tom.isBefore(tilDato)
     }
 
     override fun compareTo(other: Arbeidsgiverperiode): Int {

--- a/src/main/kotlin/no/nav/helse/sporenstreks/domene/Arbeidsgiverperiode.kt
+++ b/src/main/kotlin/no/nav/helse/sporenstreks/domene/Arbeidsgiverperiode.kt
@@ -10,10 +10,23 @@ data class Arbeidsgiverperiode(
 ) : Comparable<Arbeidsgiverperiode> {
     companion object {
         val refusjonFraDato = LocalDate.of(2020, 3, 16)
-        val refusjonTilDato = LocalDate.of(2021, 10, 1)
         val maksOppholdMellomPerioder = 16
         val maksimalAGPLengde = 16
         val arbeidsgiverBetalerForDager = 3
+    }
+
+    fun innenforGammelPeriode (arbeidsgiverPeriode: Arbeidsgiverperiode, now: LocalDate = LocalDate.now()) : Boolean {
+        val fraDato = now.minusMonths(6)
+        val tilDato = LocalDate.of(2021,10,1)
+        return arbeidsgiverPeriode.fom.isAfter(fraDato)
+            && arbeidsgiverPeriode.tom.isBefore(tilDato)
+    }
+
+    fun innenforNyPeriode (arbeidsgiverPeriode: Arbeidsgiverperiode) : Boolean {
+        val fraDato = LocalDate.of(2021,11,30)
+        val tilDato = LocalDate.of(2022,7,1)
+        return arbeidsgiverPeriode.fom.isAfter(fraDato)
+            && arbeidsgiverPeriode.tom.isBefore(tilDato)
     }
 
     override fun compareTo(other: Arbeidsgiverperiode): Int {

--- a/src/main/kotlin/no/nav/helse/sporenstreks/domene/Arbeidsgiverperiode.kt
+++ b/src/main/kotlin/no/nav/helse/sporenstreks/domene/Arbeidsgiverperiode.kt
@@ -9,24 +9,14 @@ data class Arbeidsgiverperiode(
     val beloep: Double
 ) : Comparable<Arbeidsgiverperiode> {
     companion object {
-        val refusjonFraDato = LocalDate.of(2020, 3, 16)
+        val refusjonFraDatoGammelPeriode = LocalDate.of(2020, 3, 16)
+        val refusjonTilDatoGammelPeriode = LocalDate.of(2021, 10, 1)
+        val refusjonFraDatoNyPeriode = LocalDate.of(2021, 11, 30)
+        val refusjonTilDatoNyPeriode = LocalDate.of(2022, 7, 1)
         val maksOppholdMellomPerioder = 16
         val maksimalAGPLengde = 16
-        val arbeidsgiverBetalerForDager = 3
-    }
-
-    fun innenforGammelPeriode(arbeidsgiverPeriode: Arbeidsgiverperiode, now: LocalDate = LocalDate.now()): Boolean {
-        val fraDato = now.minusMonths(6)
-        val tilDato = LocalDate.of(2021, 10, 1)
-        return arbeidsgiverPeriode.fom.isAfter(fraDato) &&
-            arbeidsgiverPeriode.tom.isBefore(tilDato)
-    }
-
-    fun innenforNyPeriode(arbeidsgiverPeriode: Arbeidsgiverperiode): Boolean {
-        val fraDato = LocalDate.of(2021, 11, 30)
-        val tilDato = LocalDate.of(2022, 7, 1)
-        return arbeidsgiverPeriode.fom.isAfter(fraDato) &&
-            arbeidsgiverPeriode.tom.isBefore(tilDato)
+        val arbeidsgiverBetalerForDagerGammelPeriode = 3
+        val arbeidsgiverBetalerForDagerNyPeriode = 5
     }
 
     override fun compareTo(other: Arbeidsgiverperiode): Int {

--- a/src/main/kotlin/no/nav/helse/sporenstreks/web/dto/RefusjonskravDto.kt
+++ b/src/main/kotlin/no/nav/helse/sporenstreks/web/dto/RefusjonskravDto.kt
@@ -5,7 +5,6 @@ import no.nav.helse.sporenstreks.domene.Arbeidsgiverperiode.Companion.arbeidsgiv
 import no.nav.helse.sporenstreks.domene.Arbeidsgiverperiode.Companion.maksOppholdMellomPerioder
 import no.nav.helse.sporenstreks.domene.Arbeidsgiverperiode.Companion.maksimalAGPLengde
 import no.nav.helse.sporenstreks.domene.Arbeidsgiverperiode.Companion.refusjonFraDato
-import no.nav.helse.sporenstreks.domene.Arbeidsgiverperiode.Companion.refusjonTilDato
 import no.nav.helse.sporenstreks.web.dto.validation.*
 import org.valiktor.functions.isGreaterThanOrEqualTo
 import org.valiktor.functions.isLessThanOrEqualTo
@@ -31,8 +30,8 @@ data class RefusjonskravDto(
                 validate(Arbeidsgiverperiode::antallDagerMedRefusjon).isPositiveOrZero()
             }
 
-            // kan ikke kreve refusjon for dager etter gjenåpning 1 oktober 2021
-            validate(RefusjonskravDto::perioder).refusjonsdatoIkkeEtterGjenåpning(refusjonTilDato)
+            // Det kan ikke kreves refusjon fra og med 1. oktober 2021 til og med 30. november 2021 eller for lenger enn 6 måneder siden.
+            validate(RefusjonskravDto::perioder).refusjonsdatoIkkeiGjenåpning()
 
             validate(RefusjonskravDto::perioder).validateForEach {
                 validate(Arbeidsgiverperiode::tom).isGreaterThanOrEqualTo(it.fom)
@@ -42,7 +41,7 @@ data class RefusjonskravDto(
             // antall refusjonsdager kan ikke være lenger enn periodens lengde
             validate(RefusjonskravDto::perioder).refujonsDagerIkkeOverstigerPeriodelengder()
 
-            // kan ikke kreve refusjon for dager før 16. mars
+            // kan ikke kreve refusjon for dager før 16. mars 2020
             validate(RefusjonskravDto::perioder).refusjonsdagerInnenforGyldigPeriode(refusjonFraDato)
 
             // Summen av antallDagerMedRefusjon kan ikke overstige total periodelengde - 3 dager

--- a/src/main/kotlin/no/nav/helse/sporenstreks/web/dto/RefusjonskravDto.kt
+++ b/src/main/kotlin/no/nav/helse/sporenstreks/web/dto/RefusjonskravDto.kt
@@ -1,10 +1,9 @@
 package no.nav.helse.sporenstreks.web.dto
 
 import no.nav.helse.sporenstreks.domene.Arbeidsgiverperiode
-import no.nav.helse.sporenstreks.domene.Arbeidsgiverperiode.Companion.arbeidsgiverBetalerForDager
 import no.nav.helse.sporenstreks.domene.Arbeidsgiverperiode.Companion.maksOppholdMellomPerioder
 import no.nav.helse.sporenstreks.domene.Arbeidsgiverperiode.Companion.maksimalAGPLengde
-import no.nav.helse.sporenstreks.domene.Arbeidsgiverperiode.Companion.refusjonFraDato
+import no.nav.helse.sporenstreks.domene.Arbeidsgiverperiode.Companion.refusjonFraDatoGammelPeriode
 import no.nav.helse.sporenstreks.web.dto.validation.*
 import org.valiktor.functions.isGreaterThanOrEqualTo
 import org.valiktor.functions.isLessThanOrEqualTo
@@ -42,10 +41,10 @@ data class RefusjonskravDto(
             validate(RefusjonskravDto::perioder).refujonsDagerIkkeOverstigerPeriodelengder()
 
             // kan ikke kreve refusjon for dager før 16. mars 2020
-            validate(RefusjonskravDto::perioder).refusjonsdagerInnenforGyldigPeriode(refusjonFraDato)
+            validate(RefusjonskravDto::perioder).refusjonsdagerInnenforGyldigPeriode(refusjonFraDatoGammelPeriode)
 
             // Summen av antallDagerMedRefusjon kan ikke overstige total periodelengde - 3 dager
-            validate(RefusjonskravDto::perioder).arbeidsgiverBetalerForDager(arbeidsgiverBetalerForDager, refusjonFraDato)
+            validate(RefusjonskravDto::perioder).arbeidsgiverBetalerForDager(refusjonFraDatoGammelPeriode)
 
             // opphold mellom periodene kan ikke overstige 16 dager
             validate(RefusjonskravDto::perioder).harMaksimaltOppholdMellomPerioder(maksOppholdMellomPerioder)

--- a/src/main/kotlin/no/nav/helse/sporenstreks/web/dto/validation/ArbeidsgiverperiodeValidations.kt
+++ b/src/main/kotlin/no/nav/helse/sporenstreks/web/dto/validation/ArbeidsgiverperiodeValidations.kt
@@ -1,0 +1,21 @@
+package no.nav.helse.sporenstreks.web.dto.validation
+
+import no.nav.helse.sporenstreks.domene.Arbeidsgiverperiode
+import java.time.LocalDate
+
+fun innenforGammelPeriode(arbeidsgiverPeriode: Arbeidsgiverperiode): Boolean {
+    val seksMndSiden = LocalDate.now().minusMonths(6)
+    return arbeidsgiverPeriode.fom.isAfter(seksMndSiden) &&
+        arbeidsgiverPeriode.tom.isBefore(Arbeidsgiverperiode.refusjonTilDatoGammelPeriode)
+}
+
+fun innenforNyPeriode(arbeidsgiverPeriode: Arbeidsgiverperiode): Boolean {
+    return arbeidsgiverPeriode.fom.isAfter(Arbeidsgiverperiode.refusjonFraDatoNyPeriode) &&
+        arbeidsgiverPeriode.tom.isBefore(Arbeidsgiverperiode.refusjonTilDatoNyPeriode)
+}
+
+fun antallDagerArbeidsgiverBetalerFor(arbeidsgiverperiode: Arbeidsgiverperiode): Int {
+    return if (innenforGammelPeriode(arbeidsgiverperiode))
+        Arbeidsgiverperiode.arbeidsgiverBetalerForDagerGammelPeriode
+    else Arbeidsgiverperiode.arbeidsgiverBetalerForDagerNyPeriode
+}

--- a/src/main/kotlin/no/nav/helse/sporenstreks/web/dto/validation/ArbeidsgiverperiodeValidations.kt
+++ b/src/main/kotlin/no/nav/helse/sporenstreks/web/dto/validation/ArbeidsgiverperiodeValidations.kt
@@ -4,8 +4,8 @@ import no.nav.helse.sporenstreks.domene.Arbeidsgiverperiode
 import java.time.LocalDate
 
 fun innenforGammelPeriode(arbeidsgiverPeriode: Arbeidsgiverperiode): Boolean {
-    val seksMndSiden = LocalDate.now().minusMonths(6)
-    return arbeidsgiverPeriode.fom.isAfter(seksMndSiden) &&
+    val treMndSiden = LocalDate.now().minusMonths(3).minusDays(1)
+    return arbeidsgiverPeriode.fom.isAfter(treMndSiden) &&
         arbeidsgiverPeriode.tom.isBefore(Arbeidsgiverperiode.refusjonTilDatoGammelPeriode)
 }
 

--- a/src/main/kotlin/no/nav/helse/sporenstreks/web/dto/validation/CustomValiktorConstraints.kt
+++ b/src/main/kotlin/no/nav/helse/sporenstreks/web/dto/validation/CustomValiktorConstraints.kt
@@ -13,15 +13,18 @@ interface CustomConstraint : Constraint {
 }
 
 class IdentitetsnummerConstraint : CustomConstraint
+
 fun <E> Validator<E>.Property<String?>.isValidIdentitetsnummer() =
     this.validate(IdentitetsnummerConstraint()) { FoedselsNrValidator.isValid(it) }
 
 class OrganisasjonsnummerConstraint : CustomConstraint
+
 fun <E> Validator<E>.Property<String?>.isValidOrganisasjonsnummer() =
     this.validate(OrganisasjonsnummerConstraint()) { OrganisasjonsnummerValidator.isValid(it) }
 
 class RefusjonsDagerConstraint : CustomConstraint
-fun <E> Validator<E>.Property<Iterable<Arbeidsgiverperiode>?>.arbeidsgiverBetalerForDager(arbeidsgiverensDager: Int, d: LocalDate) =
+
+fun <E> Validator<E>.Property<Iterable<Arbeidsgiverperiode>?>.arbeidsgiverBetalerForDager(d: LocalDate) =
     this.validate(RefusjonsDagerConstraint()) { ps ->
         var refusjonsdager = 0
         var arbeidsgiverdagerUtenRefusjon = 0
@@ -37,7 +40,7 @@ fun <E> Validator<E>.Property<Iterable<Arbeidsgiverperiode>?>.arbeidsgiverBetale
             }
         }
         val oppgitteRefusjonsdager = ps.sumOf { it.antallDagerMedRefusjon }
-
+        val arbeidsgiverensDager = antallDagerArbeidsgiverBetalerFor(ps.first())
         arbeidsgiverdagerUtenRefusjon = min(arbeidsgiverdagerUtenRefusjon, arbeidsgiverensDager)
 
         if (arbeidsgiverdagerUtenRefusjon > 0) {
@@ -48,6 +51,7 @@ fun <E> Validator<E>.Property<Iterable<Arbeidsgiverperiode>?>.arbeidsgiverBetale
     }
 
 class SammenhengeneArbeidsgiverPeriode : CustomConstraint
+
 fun <E> Validator<E>.Property<Iterable<Arbeidsgiverperiode>?>.harMaksimaltOppholdMellomPerioder(maksDagerMedOpphold: Int) =
     this.validate(SammenhengeneArbeidsgiverPeriode()) {
         val sorted = it!!.sortedBy { p -> p.fom }
@@ -70,6 +74,7 @@ fun <E> Validator<E>.Property<Iterable<Arbeidsgiverperiode>?>.harMaksimaltOpphol
     }
 
 class IngenOverlapptomePerioderContraint : CustomConstraint
+
 fun <E> Validator<E>.Property<Iterable<Arbeidsgiverperiode>?>.harIngenOverlappendePerioder() =
     this.validate(IngenOverlapptomePerioderContraint()) {
         !it!!.any { a ->
@@ -80,6 +85,7 @@ fun <E> Validator<E>.Property<Iterable<Arbeidsgiverperiode>?>.harIngenOverlappen
     }
 
 class MaksArbeidsgiverperiodeLengdeConstraint : CustomConstraint
+
 fun <E> Validator<E>.Property<Iterable<Arbeidsgiverperiode>?>.totalPeriodeLengdeErMaks(maksDager: Int) =
     this.validate(MaksArbeidsgiverperiodeLengdeConstraint()) { ps ->
         val sum = ps!!.map {
@@ -89,6 +95,7 @@ fun <E> Validator<E>.Property<Iterable<Arbeidsgiverperiode>?>.totalPeriodeLengde
     }
 
 class RefusjonsdagerKanIkkeOverstigePeriodelengdenConstraint : CustomConstraint
+
 fun <E> Validator<E>.Property<Iterable<Arbeidsgiverperiode>?>.refujonsDagerIkkeOverstigerPeriodelengder() =
     this.validate(RefusjonsdagerKanIkkeOverstigePeriodelengdenConstraint()) { ps ->
         !ps!!.any { p ->
@@ -97,6 +104,7 @@ fun <E> Validator<E>.Property<Iterable<Arbeidsgiverperiode>?>.refujonsDagerIkkeO
     }
 
 class TomPeriodeKanIkkeHaBeloepConstraint : CustomConstraint
+
 fun <E> Validator<E>.Property<Iterable<Arbeidsgiverperiode>?>.tomPeriodeKanIkkeHaBeloepConstraint() =
     this.validate(TomPeriodeKanIkkeHaBeloepConstraint()) { ps ->
         !ps!!.any { p ->
@@ -105,6 +113,7 @@ fun <E> Validator<E>.Property<Iterable<Arbeidsgiverperiode>?>.tomPeriodeKanIkkeH
     }
 
 class RefusjonsdagerInnenforGyldigPeriodeConstraint : CustomConstraint
+
 fun <E> Validator<E>.Property<Iterable<Arbeidsgiverperiode>?>.refusjonsdagerInnenforGyldigPeriode(refusjonsdagerFom: LocalDate) =
     this.validate(RefusjonsdagerInnenforGyldigPeriodeConstraint()) { ps ->
         ps!!.all { p ->
@@ -114,9 +123,10 @@ fun <E> Validator<E>.Property<Iterable<Arbeidsgiverperiode>?>.refusjonsdagerInne
     }
 
 class RefusjonsdagerInnenforGjenaapningConstraint : CustomConstraint
+
 fun <E> Validator<E>.Property<Iterable<Arbeidsgiverperiode>?>.refusjonsdatoIkkeiGjenåpning() =
     this.validate(RefusjonsdagerInnenforGjenaapningConstraint()) { ps ->
         ps!!.all { p ->
-            p.innenforGammelPeriode(p) || p.innenforNyPeriode(p)
+            innenforGammelPeriode(p) || innenforNyPeriode(p)
         }
     }

--- a/src/main/kotlin/no/nav/helse/sporenstreks/web/dto/validation/CustomValiktorConstraints.kt
+++ b/src/main/kotlin/no/nav/helse/sporenstreks/web/dto/validation/CustomValiktorConstraints.kt
@@ -36,7 +36,7 @@ fun <E> Validator<E>.Property<Iterable<Arbeidsgiverperiode>?>.arbeidsgiverBetale
                 arbeidsgiverdagerUtenRefusjon += ChronoUnit.DAYS.between(it.fom, d).toInt()
             }
         }
-        val oppgitteRefusjonsdager = ps!!.sumBy { it.antallDagerMedRefusjon }
+        val oppgitteRefusjonsdager = ps.sumOf { it.antallDagerMedRefusjon }
 
         arbeidsgiverdagerUtenRefusjon = min(arbeidsgiverdagerUtenRefusjon, arbeidsgiverensDager)
 
@@ -114,9 +114,9 @@ fun <E> Validator<E>.Property<Iterable<Arbeidsgiverperiode>?>.refusjonsdagerInne
     }
 
 class RefusjonsdagerInnenforGjenaapningConstraint : CustomConstraint
-fun <E> Validator<E>.Property<Iterable<Arbeidsgiverperiode>?>.refusjonsdatoIkkeEtterGjenåpning(refusjonsdagerTom: LocalDate) =
+fun <E> Validator<E>.Property<Iterable<Arbeidsgiverperiode>?>.refusjonsdatoIkkeiGjenåpning() =
     this.validate(RefusjonsdagerInnenforGjenaapningConstraint()) { ps ->
         ps!!.all { p ->
-            (p.fom < refusjonsdagerTom)
+            p.innenforGammelPeriode(p) || p.innenforNyPeriode(p)
         }
     }

--- a/src/main/resources/validation/validation-messages.properties
+++ b/src/main/resources/validation/validation-messages.properties
@@ -1,7 +1,7 @@
 no.nav.helse.sporenstreks.web.dto.validation.IdentitetsnummerConstraint.message=Ugyldig fødsels- eller D-nummer
 no.nav.helse.sporenstreks.web.dto.validation.OrganisasjonsnummerConstraint.message=Ugyldig virksomhetsnummer
 no.nav.helse.sporenstreks.web.dto.validation.RefusjonsDagerConstraint.message=Det kan ikke kreves refusjon for de 3 første dagene i arbeidsgiverperioden.
-no.nav.helse.sporenstreks.web.dto.validation.RefusjonsdagerInnenforGjenaapningConstraint.message=Det kan ikke kreves refusjon fra og med 1 oktober 2021
+no.nav.helse.sporenstreks.web.dto.validation.RefusjonsdagerInnenforGjenaapningConstraint.message=Det kan ikke kreves refusjon fra og med 1. oktober 2021 til og med 30. november 2021 eller for lenger enn 6 måneder siden.
 no.nav.helse.sporenstreks.web.dto.validation.SammenhengeneArbeidsgiverPeriode.message=Det kan maksimalt være 16 dager mellom periodene
 no.nav.helse.sporenstreks.web.dto.validation.IngenOverlapptomePerioderContraint.message=Periodene kan ikke overlappe hverandre
 no.nav.helse.sporenstreks.web.dto.validation.MaksArbeidsgiverperiodeLengdeConstraint.message=Perioden(e) kan ikke være mer enn 16 dager til sammen

--- a/src/main/resources/validation/validation-messages.properties
+++ b/src/main/resources/validation/validation-messages.properties
@@ -1,6 +1,6 @@
 no.nav.helse.sporenstreks.web.dto.validation.IdentitetsnummerConstraint.message=Ugyldig fødsels- eller D-nummer
 no.nav.helse.sporenstreks.web.dto.validation.OrganisasjonsnummerConstraint.message=Ugyldig virksomhetsnummer
-no.nav.helse.sporenstreks.web.dto.validation.RefusjonsDagerConstraint.message=Det kan ikke kreves refusjon for de 3 første dagene i arbeidsgiverperioden.
+no.nav.helse.sporenstreks.web.dto.validation.RefusjonsDagerConstraint.message=Det kan ikke kreves refusjon for de 3 første dagene i arbeidsgiverperioden mellom 16. mars 2020 og 1. desember 2021.\nFor arbeidsgiverperioden mellom 1. desember 2021 og 30. juni 2022 kan det ikke kreves refusjon for de 5 første dagene.
 no.nav.helse.sporenstreks.web.dto.validation.RefusjonsdagerInnenforGjenaapningConstraint.message=Det kan ikke kreves refusjon fra og med 1. oktober 2021 til og med 30. november 2021 eller for lenger enn 6 måneder siden.
 no.nav.helse.sporenstreks.web.dto.validation.SammenhengeneArbeidsgiverPeriode.message=Det kan maksimalt være 16 dager mellom periodene
 no.nav.helse.sporenstreks.web.dto.validation.IngenOverlapptomePerioderContraint.message=Periodene kan ikke overlappe hverandre

--- a/src/test/kotlin/no/nav/helse/sporenstreks/excel/ExcelParserTest.kt
+++ b/src/test/kotlin/no/nav/helse/sporenstreks/excel/ExcelParserTest.kt
@@ -2,6 +2,7 @@ package no.nav.helse.sporenstreks.excel
 
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import io.mockk.verify
 import no.nav.helse.TestData
 import no.nav.helse.arbeidsgiver.web.auth.AltinnAuthorizer
@@ -10,6 +11,7 @@ import org.apache.poi.xssf.usermodel.XSSFWorkbook
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.time.LocalDate
 
 internal class ExcelParserTest {
 
@@ -21,6 +23,8 @@ internal class ExcelParserTest {
     @BeforeEach
     fun setup() {
         every { authorizerMock.hasAccess(any(), any()) } returns true
+        mockkStatic(LocalDate::class)
+        every { LocalDate.now() } returns LocalDate.parse("2020-06-06")
     }
 
     @Test

--- a/src/test/kotlin/no/nav/helse/sporenstreks/web/dto/RefusjonsKravDtoTest.kt
+++ b/src/test/kotlin/no/nav/helse/sporenstreks/web/dto/RefusjonsKravDtoTest.kt
@@ -1,13 +1,50 @@
 package no.nav.helse.sporenstreks.web.dto
 
+import io.mockk.every
+import io.mockk.mockkStatic
 import no.nav.helse.TestData
 import no.nav.helse.sporenstreks.domene.Arbeidsgiverperiode
 import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import org.valiktor.ConstraintViolationException
 import java.time.LocalDate
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal class RefusjonsKravDtoTest {
+
+    @BeforeAll
+    fun setup() {
+        mockkStatic(LocalDate::class)
+        every { LocalDate.now() } returns LocalDate.parse("2021-12-06")
+    }
+
+    @Test
+    fun `Refusjonskrav i ny periode validerer OK`() {
+        RefusjonskravDto(
+            TestData.validIdentitetsnummer,
+            TestData.validOrgNr,
+            setOf(Arbeidsgiverperiode(
+                LocalDate.of(2021, 12, 2),
+                LocalDate.of(2021, 12, 6),
+                2, 2.3
+            ))
+        )
+    }
+
+    @Test
+    fun `Refusjonskrav i gammel periode validerer OK`() {
+        RefusjonskravDto(
+            TestData.validIdentitetsnummer,
+            TestData.validOrgNr,
+            setOf(Arbeidsgiverperiode(
+                LocalDate.of(2021, 9, 2),
+                LocalDate.of(2021, 9, 6),
+                2, 2.3
+            ))
+        )
+    }
 
     @Test
     fun `Gyldig refusjonskrav validerer OK`() {
@@ -16,13 +53,13 @@ internal class RefusjonsKravDtoTest {
             TestData.validOrgNr,
             setOf(
                 Arbeidsgiverperiode(
-                    LocalDate.of(2020, 3, 18),
-                    LocalDate.of(2020, 3, 21),
+                    LocalDate.of(2021, 9, 18),
+                    LocalDate.of(2021, 9, 21),
                     2, 2.3
                 ),
                 Arbeidsgiverperiode(
-                    LocalDate.of(2020, 3, 22),
-                    LocalDate.of(2020, 3, 29),
+                    LocalDate.of(2021, 9, 22),
+                    LocalDate.of(2021, 9, 29),
                     4, 2.4
                 )
             )
@@ -36,13 +73,13 @@ internal class RefusjonsKravDtoTest {
             TestData.validOrgNr,
             setOf(
                 Arbeidsgiverperiode(
-                    LocalDate.of(2020, 3, 16),
-                    LocalDate.of(2020, 3, 21),
+                    LocalDate.of(2021, 9, 16),
+                    LocalDate.of(2021, 9, 21),
                     2, 2.0
                 ),
                 Arbeidsgiverperiode(
-                    LocalDate.of(2020, 3, 21),
-                    LocalDate.of(2020, 3, 25),
+                    LocalDate.of(2021, 9, 21),
+                    LocalDate.of(2021, 9, 25),
                     4, 2.0
                 )
             )
@@ -57,13 +94,13 @@ internal class RefusjonsKravDtoTest {
                 TestData.validOrgNr,
                 setOf(
                     Arbeidsgiverperiode(
-                        LocalDate.of(2020, 4, 1),
-                        LocalDate.of(2020, 4, 6),
+                        LocalDate.of(2021, 9, 1),
+                        LocalDate.of(2021, 9, 6),
                         2, 1.0
                     ),
                     Arbeidsgiverperiode(
-                        LocalDate.of(2020, 4, 5),
-                        LocalDate.of(2020, 4, 10),
+                        LocalDate.of(2021, 9, 5),
+                        LocalDate.of(2021, 9, 10),
                         4, 2.0
                     )
                 )
@@ -79,8 +116,8 @@ internal class RefusjonsKravDtoTest {
                 TestData.validOrgNr,
                 setOf(
                     Arbeidsgiverperiode(
-                        LocalDate.of(2020, 4, 1),
-                        LocalDate.of(2020, 4, 5),
+                        LocalDate.of(2021, 9, 1),
+                        LocalDate.of(2021, 9, 5),
                         2, -14.65
                     )
                 )
@@ -96,13 +133,13 @@ internal class RefusjonsKravDtoTest {
                 TestData.validOrgNr,
                 setOf(
                     Arbeidsgiverperiode(
-                        LocalDate.of(2020, 4, 1),
-                        LocalDate.of(2020, 4, 5),
+                        LocalDate.of(2021, 9, 1),
+                        LocalDate.of(2021, 9, 5),
                         2, 2.0
                     ),
                     Arbeidsgiverperiode(
-                        LocalDate.of(2020, 4, 23),
-                        LocalDate.of(2020, 4, 29),
+                        LocalDate.of(2021, 9, 23),
+                        LocalDate.of(2021, 9, 29),
                         8, 0.0
                     )
                 )
@@ -118,13 +155,13 @@ internal class RefusjonsKravDtoTest {
                 TestData.validOrgNr,
                 setOf(
                     Arbeidsgiverperiode(
-                        LocalDate.of(2020, 4, 1),
-                        LocalDate.of(2020, 4, 5),
+                        LocalDate.of(2021, 9, 1),
+                        LocalDate.of(2021, 9, 5),
                         5, 2.0
                     ),
                     Arbeidsgiverperiode(
-                        LocalDate.of(2020, 4, 20),
-                        LocalDate.of(2020, 4, 29),
+                        LocalDate.of(2021, 9, 20),
+                        LocalDate.of(2021, 9, 29),
                         9, 2.0
                     )
                 )
@@ -140,13 +177,13 @@ internal class RefusjonsKravDtoTest {
                 TestData.validOrgNr,
                 setOf(
                     Arbeidsgiverperiode(
-                        LocalDate.of(2020, 4, 1),
-                        LocalDate.of(2020, 4, 6),
+                        LocalDate.of(2021, 9, 1),
+                        LocalDate.of(2021, 9, 6),
                         5, 2.0
                     ),
                     Arbeidsgiverperiode(
-                        LocalDate.of(2020, 4, 10),
-                        LocalDate.of(2020, 4, 20),
+                        LocalDate.of(2021, 9, 10),
+                        LocalDate.of(2021, 9, 20),
                         9, 2.0
                     )
                 )
@@ -161,13 +198,13 @@ internal class RefusjonsKravDtoTest {
             TestData.validOrgNr,
             setOf(
                 Arbeidsgiverperiode(
-                    LocalDate.of(2020, 3, 13),
-                    LocalDate.of(2020, 3, 17),
+                    LocalDate.of(2021, 9, 13),
+                    LocalDate.of(2021, 9, 17),
                     2, 2.0
                 ),
                 Arbeidsgiverperiode(
-                    LocalDate.of(2020, 3, 17),
-                    LocalDate.of(2020, 3, 27),
+                    LocalDate.of(2021, 9, 17),
+                    LocalDate.of(2021, 9, 27),
                     11, 2.0
                 )
             )
@@ -181,8 +218,8 @@ internal class RefusjonsKravDtoTest {
             TestData.validOrgNr,
             setOf(
                 Arbeidsgiverperiode(
-                    LocalDate.of(2020, 3, 16),
-                    LocalDate.of(2020, 3, 31),
+                    LocalDate.of(2021, 9, 15),
+                    LocalDate.of(2021, 9, 30),
                     13, 2.0
                 )
             )
@@ -197,8 +234,8 @@ internal class RefusjonsKravDtoTest {
                 TestData.validOrgNr,
                 setOf(
                     Arbeidsgiverperiode(
-                        LocalDate.of(2020, 4, 1),
-                        LocalDate.of(2020, 4, 6),
+                        LocalDate.of(2021, 9, 1),
+                        LocalDate.of(2021, 9, 6),
                         7, 2.0
                     )
                 )
@@ -214,8 +251,8 @@ internal class RefusjonsKravDtoTest {
                 TestData.validOrgNr,
                 setOf(
                     Arbeidsgiverperiode(
-                        LocalDate.of(2020, 4, 1),
-                        LocalDate.of(2020, 4, 6),
+                        LocalDate.of(2021, 9, 1),
+                        LocalDate.of(2021, 9, 6),
                         4, 2000.0
                     ),
                     Arbeidsgiverperiode(
@@ -235,8 +272,8 @@ internal class RefusjonsKravDtoTest {
             TestData.validOrgNr,
             setOf(
                 Arbeidsgiverperiode(
-                    LocalDate.of(2020, 3, 9),
-                    LocalDate.of(2020, 3, 19),
+                    LocalDate.of(2021, 9, 9),
+                    LocalDate.of(2021, 9, 19),
                     4, 2000.0
                 )
             )
@@ -244,7 +281,7 @@ internal class RefusjonsKravDtoTest {
     }
 
     @Test
-    fun `Perioder kan ikke være etter gjenåpning 30 september 2021`() {
+    fun `Det kan ikke kreves refusjon fra og med 1 oktober 2021 til og med 30 november 2021`() {
         Assertions.assertThatExceptionOfType(ConstraintViolationException::class.java).isThrownBy {
             RefusjonskravDto(
                 TestData.validIdentitetsnummer,
@@ -267,13 +304,13 @@ internal class RefusjonsKravDtoTest {
             TestData.validOrgNr,
             setOf(
                 Arbeidsgiverperiode(
-                    LocalDate.of(2020, 3, 10),
-                    LocalDate.of(2020, 3, 15),
+                    LocalDate.of(2021, 9, 10),
+                    LocalDate.of(2021, 9, 15),
                     0, 0.0
                 ),
                 Arbeidsgiverperiode(
-                    LocalDate.of(2020, 3, 20),
-                    LocalDate.of(2020, 3, 25),
+                    LocalDate.of(2021, 9, 20),
+                    LocalDate.of(2021, 9, 25),
                     5, 10000.0
                 )
             )
@@ -285,8 +322,8 @@ internal class RefusjonsKravDtoTest {
                 TestData.validOrgNr,
                 setOf(
                     Arbeidsgiverperiode(
-                        LocalDate.of(2020, 4, 10),
-                        LocalDate.of(2020, 4, 15),
+                        LocalDate.of(2021, 9, 10),
+                        LocalDate.of(2021, 9, 15),
                         5, 10000.0
                     )
                 )
@@ -295,37 +332,15 @@ internal class RefusjonsKravDtoTest {
     }
 
     @Test
-    fun `Må inneholde minst en periode med dager etter 16 mars`() {
+    fun `Kan ikke kreve refusjon for dager før seks måneder siden`() {
         Assertions.assertThatExceptionOfType(ConstraintViolationException::class.java).isThrownBy {
             RefusjonskravDto(
                 TestData.validIdentitetsnummer,
                 TestData.validOrgNr,
                 setOf(
                     Arbeidsgiverperiode(
-                        LocalDate.of(2020, 2, 20),
-                        LocalDate.of(2020, 2, 25),
-                        0, 0.0
-                    ),
-                    Arbeidsgiverperiode(
-                        LocalDate.of(2020, 2, 15),
-                        LocalDate.of(2020, 3, 15),
-                        5, 10000.0
-                    )
-                )
-            )
-        }
-    }
-
-    @Test
-    fun `Kan ikke kreve refusjon for dager før 16 mars`() {
-        Assertions.assertThatExceptionOfType(ConstraintViolationException::class.java).isThrownBy {
-            RefusjonskravDto(
-                TestData.validIdentitetsnummer,
-                TestData.validOrgNr,
-                setOf(
-                    Arbeidsgiverperiode(
-                        LocalDate.of(2020, 3, 10),
-                        LocalDate.of(2020, 3, 17),
+                        LocalDate.of(2021, 6, 5),
+                        LocalDate.of(2021, 6, 17),
                         4, 4000.0
                     )
                 )
@@ -337,8 +352,8 @@ internal class RefusjonsKravDtoTest {
             TestData.validOrgNr,
             setOf(
                 Arbeidsgiverperiode(
-                    LocalDate.of(2020, 3, 10),
-                    LocalDate.of(2020, 3, 17),
+                    LocalDate.of(2021, 7, 10),
+                    LocalDate.of(2021, 7, 17),
                     0, 0.0
                 )
             )

--- a/src/test/kotlin/no/nav/helse/sporenstreks/web/dto/RefusjonsKravDtoTest.kt
+++ b/src/test/kotlin/no/nav/helse/sporenstreks/web/dto/RefusjonsKravDtoTest.kt
@@ -17,7 +17,7 @@ internal class RefusjonsKravDtoTest {
     @BeforeAll
     fun setup() {
         mockkStatic(LocalDate::class)
-        every { LocalDate.now() } returns LocalDate.parse("2021-12-06")
+        every { LocalDate.now() } returns LocalDate.parse("2021-12-15")
     }
 
     @Test
@@ -27,8 +27,8 @@ internal class RefusjonsKravDtoTest {
             TestData.validOrgNr,
             setOf(
                 Arbeidsgiverperiode(
-                    LocalDate.of(2021, 12, 2),
-                    LocalDate.of(2021, 12, 6),
+                    LocalDate.of(2021, 12, 1),
+                    LocalDate.of(2021, 12, 7),
                     2, 2.3
                 )
             )
@@ -248,7 +248,58 @@ internal class RefusjonsKravDtoTest {
     }
 
     @Test
-    fun `Maks refusjonsdager er totalperiode minus 3 dager`() {
+    fun `Maks refusjonsdager er totalperiode minus 5 dager for ny periode`() {
+        RefusjonskravDto(
+            TestData.validIdentitetsnummer,
+            TestData.validOrgNr,
+            setOf(
+                Arbeidsgiverperiode(
+                    LocalDate.of(2021, 12, 1),
+                    LocalDate.of(2021, 12, 6),
+                    1, 2000.0
+                ),
+                Arbeidsgiverperiode(
+                    LocalDate.of(2021, 12, 6),
+                    LocalDate.of(2021, 12, 7),
+                    2, 2000.0
+                )
+            )
+        )
+
+        Assertions.assertThatExceptionOfType(ConstraintViolationException::class.java).isThrownBy {
+            RefusjonskravDto(
+                TestData.validIdentitetsnummer,
+                TestData.validOrgNr,
+                setOf(
+                    Arbeidsgiverperiode(
+                        LocalDate.of(2021, 12, 1),
+                        LocalDate.of(2021, 12, 6),
+                        1, 2000.0
+                    ),
+                    Arbeidsgiverperiode(
+                        LocalDate.of(2021, 12, 6),
+                        LocalDate.of(2021, 12, 7),
+                        3, 2000.0
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `Maks refusjonsdager er totalperiode minus 3 dager for gammel periode`() {
+        RefusjonskravDto(
+            TestData.validIdentitetsnummer,
+            TestData.validOrgNr,
+            setOf(
+                Arbeidsgiverperiode(
+                    LocalDate.of(2021, 9, 1),
+                    LocalDate.of(2021, 9, 4),
+                    1, 2000.0
+                )
+            )
+        )
+
         Assertions.assertThatExceptionOfType(ConstraintViolationException::class.java).isThrownBy {
             RefusjonskravDto(
                 TestData.validIdentitetsnummer,
@@ -260,8 +311,8 @@ internal class RefusjonsKravDtoTest {
                         4, 2000.0
                     ),
                     Arbeidsgiverperiode(
-                        LocalDate.of(2020, 4, 10),
-                        LocalDate.of(2020, 4, 12),
+                        LocalDate.of(2021, 9, 10),
+                        LocalDate.of(2021, 9, 12),
                         3, 1500.0
                     )
                 )

--- a/src/test/kotlin/no/nav/helse/sporenstreks/web/dto/RefusjonsKravDtoTest.kt
+++ b/src/test/kotlin/no/nav/helse/sporenstreks/web/dto/RefusjonsKravDtoTest.kt
@@ -25,11 +25,13 @@ internal class RefusjonsKravDtoTest {
         RefusjonskravDto(
             TestData.validIdentitetsnummer,
             TestData.validOrgNr,
-            setOf(Arbeidsgiverperiode(
-                LocalDate.of(2021, 12, 2),
-                LocalDate.of(2021, 12, 6),
-                2, 2.3
-            ))
+            setOf(
+                Arbeidsgiverperiode(
+                    LocalDate.of(2021, 12, 2),
+                    LocalDate.of(2021, 12, 6),
+                    2, 2.3
+                )
+            )
         )
     }
 
@@ -38,11 +40,13 @@ internal class RefusjonsKravDtoTest {
         RefusjonskravDto(
             TestData.validIdentitetsnummer,
             TestData.validOrgNr,
-            setOf(Arbeidsgiverperiode(
-                LocalDate.of(2021, 9, 2),
-                LocalDate.of(2021, 9, 6),
-                2, 2.3
-            ))
+            setOf(
+                Arbeidsgiverperiode(
+                    LocalDate.of(2021, 9, 2),
+                    LocalDate.of(2021, 9, 6),
+                    2, 2.3
+                )
+            )
         )
     }
 

--- a/src/test/kotlin/no/nav/helse/sporenstreks/web/dto/RefusjonsKravDtoTest.kt
+++ b/src/test/kotlin/no/nav/helse/sporenstreks/web/dto/RefusjonsKravDtoTest.kt
@@ -17,7 +17,7 @@ internal class RefusjonsKravDtoTest {
     @BeforeAll
     fun setup() {
         mockkStatic(LocalDate::class)
-        every { LocalDate.now() } returns LocalDate.parse("2021-12-15")
+        every { LocalDate.now() } returns LocalDate.parse("2021-12-07")
     }
 
     @Test
@@ -42,8 +42,8 @@ internal class RefusjonsKravDtoTest {
             TestData.validOrgNr,
             setOf(
                 Arbeidsgiverperiode(
-                    LocalDate.of(2021, 9, 2),
-                    LocalDate.of(2021, 9, 6),
+                    LocalDate.of(2021, 9, 8),
+                    LocalDate.of(2021, 9, 12),
                     2, 2.3
                 )
             )
@@ -98,13 +98,13 @@ internal class RefusjonsKravDtoTest {
                 TestData.validOrgNr,
                 setOf(
                     Arbeidsgiverperiode(
-                        LocalDate.of(2021, 9, 1),
-                        LocalDate.of(2021, 9, 6),
+                        LocalDate.of(2021, 9, 16),
+                        LocalDate.of(2021, 9, 21),
                         2, 1.0
                     ),
                     Arbeidsgiverperiode(
-                        LocalDate.of(2021, 9, 5),
-                        LocalDate.of(2021, 9, 10),
+                        LocalDate.of(2021, 9, 20),
+                        LocalDate.of(2021, 9, 25),
                         4, 2.0
                     )
                 )
@@ -120,8 +120,8 @@ internal class RefusjonsKravDtoTest {
                 TestData.validOrgNr,
                 setOf(
                     Arbeidsgiverperiode(
-                        LocalDate.of(2021, 9, 1),
-                        LocalDate.of(2021, 9, 5),
+                        LocalDate.of(2021, 9, 8),
+                        LocalDate.of(2021, 9, 15),
                         2, -14.65
                     )
                 )
@@ -137,14 +137,14 @@ internal class RefusjonsKravDtoTest {
                 TestData.validOrgNr,
                 setOf(
                     Arbeidsgiverperiode(
-                        LocalDate.of(2021, 9, 1),
-                        LocalDate.of(2021, 9, 5),
-                        2, 2.0
+                        LocalDate.of(2021, 9, 7),
+                        LocalDate.of(2021, 9, 8),
+                        0, 0.0
                     ),
                     Arbeidsgiverperiode(
-                        LocalDate.of(2021, 9, 23),
+                        LocalDate.of(2021, 9, 26),
                         LocalDate.of(2021, 9, 29),
-                        8, 0.0
+                        2, 0.0
                     )
                 )
             )
@@ -159,8 +159,8 @@ internal class RefusjonsKravDtoTest {
                 TestData.validOrgNr,
                 setOf(
                     Arbeidsgiverperiode(
-                        LocalDate.of(2021, 9, 1),
-                        LocalDate.of(2021, 9, 5),
+                        LocalDate.of(2021, 9, 7),
+                        LocalDate.of(2021, 9, 19),
                         5, 2.0
                     ),
                     Arbeidsgiverperiode(
@@ -181,13 +181,13 @@ internal class RefusjonsKravDtoTest {
                 TestData.validOrgNr,
                 setOf(
                     Arbeidsgiverperiode(
-                        LocalDate.of(2021, 9, 1),
-                        LocalDate.of(2021, 9, 6),
+                        LocalDate.of(2021, 9, 10),
+                        LocalDate.of(2021, 9, 20),
                         5, 2.0
                     ),
                     Arbeidsgiverperiode(
-                        LocalDate.of(2021, 9, 10),
                         LocalDate.of(2021, 9, 20),
+                        LocalDate.of(2021, 9, 30),
                         9, 2.0
                     )
                 )
@@ -202,14 +202,14 @@ internal class RefusjonsKravDtoTest {
             TestData.validOrgNr,
             setOf(
                 Arbeidsgiverperiode(
-                    LocalDate.of(2021, 9, 13),
-                    LocalDate.of(2021, 9, 17),
-                    2, 2.0
+                    LocalDate.of(2021, 9, 14),
+                    LocalDate.of(2021, 9, 21),
+                    2, 2.3
                 ),
                 Arbeidsgiverperiode(
-                    LocalDate.of(2021, 9, 17),
-                    LocalDate.of(2021, 9, 27),
-                    11, 2.0
+                    LocalDate.of(2021, 9, 22),
+                    LocalDate.of(2021, 9, 29),
+                    4, 2.4
                 )
             )
         )
@@ -238,8 +238,8 @@ internal class RefusjonsKravDtoTest {
                 TestData.validOrgNr,
                 setOf(
                     Arbeidsgiverperiode(
-                        LocalDate.of(2021, 9, 1),
-                        LocalDate.of(2021, 9, 6),
+                        LocalDate.of(2021, 9, 10),
+                        LocalDate.of(2021, 9, 16),
                         7, 2.0
                     )
                 )
@@ -293,8 +293,8 @@ internal class RefusjonsKravDtoTest {
             TestData.validOrgNr,
             setOf(
                 Arbeidsgiverperiode(
-                    LocalDate.of(2021, 9, 1),
-                    LocalDate.of(2021, 9, 4),
+                    LocalDate.of(2021, 9, 15),
+                    LocalDate.of(2021, 9, 19),
                     1, 2000.0
                 )
             )
@@ -306,14 +306,9 @@ internal class RefusjonsKravDtoTest {
                 TestData.validOrgNr,
                 setOf(
                     Arbeidsgiverperiode(
-                        LocalDate.of(2021, 9, 1),
-                        LocalDate.of(2021, 9, 6),
-                        4, 2000.0
-                    ),
-                    Arbeidsgiverperiode(
                         LocalDate.of(2021, 9, 10),
-                        LocalDate.of(2021, 9, 12),
-                        3, 1500.0
+                        LocalDate.of(2021, 9, 15),
+                        4, 2000.0
                     )
                 )
             )
@@ -327,8 +322,8 @@ internal class RefusjonsKravDtoTest {
             TestData.validOrgNr,
             setOf(
                 Arbeidsgiverperiode(
-                    LocalDate.of(2021, 9, 9),
-                    LocalDate.of(2021, 9, 19),
+                    LocalDate.of(2021, 9, 15),
+                    LocalDate.of(2021, 9, 22),
                     4, 2000.0
                 )
             )
@@ -359,13 +354,13 @@ internal class RefusjonsKravDtoTest {
             TestData.validOrgNr,
             setOf(
                 Arbeidsgiverperiode(
-                    LocalDate.of(2021, 9, 10),
                     LocalDate.of(2021, 9, 15),
+                    LocalDate.of(2021, 9, 20),
                     0, 0.0
                 ),
                 Arbeidsgiverperiode(
-                    LocalDate.of(2021, 9, 20),
                     LocalDate.of(2021, 9, 25),
+                    LocalDate.of(2021, 9, 30),
                     5, 10000.0
                 )
             )
@@ -387,15 +382,15 @@ internal class RefusjonsKravDtoTest {
     }
 
     @Test
-    fun `Kan ikke kreve refusjon for dager før seks måneder siden`() {
+    fun `Kan ikke kreve refusjon for dager før tre måneder siden`() {
         Assertions.assertThatExceptionOfType(ConstraintViolationException::class.java).isThrownBy {
             RefusjonskravDto(
                 TestData.validIdentitetsnummer,
                 TestData.validOrgNr,
                 setOf(
                     Arbeidsgiverperiode(
-                        LocalDate.of(2021, 6, 5),
-                        LocalDate.of(2021, 6, 17),
+                        LocalDate.of(2021, 9, 1),
+                        LocalDate.of(2021, 9, 10),
                         4, 4000.0
                     )
                 )
@@ -407,8 +402,8 @@ internal class RefusjonsKravDtoTest {
             TestData.validOrgNr,
             setOf(
                 Arbeidsgiverperiode(
-                    LocalDate.of(2021, 7, 10),
-                    LocalDate.of(2021, 7, 17),
+                    LocalDate.of(2021, 9, 15),
+                    LocalDate.of(2021, 9, 17),
                     0, 0.0
                 )
             )


### PR DESCRIPTION
Søke på **gammel periode**:
Fra: dagens dato - 6 mnd
Til: 01.10.21
Arbeidsgiver betaler for dager: 3 dager

Søke på **ny periode**:
Fra: 01.12.21
Til: 30.06.2022
Arbeidsgiver betaler for dager: 5 dager

Skal ikke kunne søke for perioder mellom 30.09.21 - 30.11.21.