### PR TITLE
Endrer sjekk for 3 mnd frist samt tester fixes #92

### DIFF
--- a/src/main/kotlin/no/nav/helse/sporenstreks/web/dto/validation/CustomValiktorConstraints.kt
+++ b/src/main/kotlin/no/nav/helse/sporenstreks/web/dto/validation/CustomValiktorConstraints.kt
@@ -160,6 +160,7 @@ fun <E> Validator<E>.Property<Iterable<Arbeidsgiverperiode>?>.innenforAntallMån
     this.validate(RefusjonsdagerInnenforAntallMånederConstraint(mapOf("antall" to antallMåneder.toString()))) { ps ->
         val antallMånederSiden = LocalDate.now()
             .minusMonths(antallMåneder)
+            .withDayOfMonth(1)
 
         ps!!.all { p ->
             p.fom.isAfter(antallMånederSiden)


### PR DESCRIPTION
Regelen for 3-månedersfristen er feil i sporenstreks. Regelen er slik at det skal være mulig å søke 3 måneder tilbake i tid. Dette inkluderer den måneden man er i når man søker. Det må derfor være mulig å søke tilbake til tid ut mars.

Denne PR-en endrer fra den opprinnlige sjekken; fra og med (FOM) datoen i arbeidsgiverperioden er _etter_ (dagens dato - 3 mnd).

Til: fra og med (FOM) datoen i arbeidsgiverperioden er _etter_ (dagens dato - 3 mnd **og første dag i denne måneden**).


Altså fra `.minusMonths(antallMåneder)` til `.minusMonths(antallMåneder).withDayOfMonth(1)`

For mer informasjon se [issuet](https://github.com/navikt/sporenstreks/issues/92)
