### PR TITLE
skravering av fødselsnummer på kvittering.

### DIFF
--- a/src/main/kotlin/no/nav/helse/sporenstreks/kvittering/AltinnKvitteringMapper.kt
+++ b/src/main/kotlin/no/nav/helse/sporenstreks/kvittering/AltinnKvitteringMapper.kt
@@ -42,9 +42,10 @@ class AltinnKvitteringMapper(val altinnTjenesteKode: String) {
             krav.perioder.sorted().joinToString(
                 separator = "\n"
             ) {
+                val sladdetFnr = sladdFnr(krav.identitetsnummer)
                 """
                                 <tr>
-                                <td style="padding:12px">${krav.identitetsnummer}</td>
+                                <td style="padding:12px">$sladdetFnr</td>
                                 <td style="padding:12px">${it.fom.format(dateFormatter)} - ${it.tom.format(dateFormatter)}</td>
                                 <td style="padding:12px">${it.antallDagerMedRefusjon}</td>
                                 <td style="padding:12px">${it.beloep}</td>
@@ -73,5 +74,9 @@ class AltinnKvitteringMapper(val altinnTjenesteKode: String) {
             .withServiceCode(altinnTjenesteKode)
             .withServiceEdition("1")
             .withContent(meldingsInnhold)
+    }
+
+    fun sladdFnr(fnr: String): String {
+        return fnr.take(6) + "*****"
     }
 }


### PR DESCRIPTION
fødselsnummer kan ikke være med på overskrift slik som i fritakAGP, siden kvitteringene i sporenstreks kan inneholde mange indentitetsnummer. I fritakagp er kvitteringene per person.