### PR TITLE
Kan ikke kreve refusjon for etter gjenåpning 01.07.22

### DIFF
--- a/src/main/kotlin/no/nav/helse/sporenstreks/domene/Arbeidsgiverperiode.kt
+++ b/src/main/kotlin/no/nav/helse/sporenstreks/domene/Arbeidsgiverperiode.kt
@@ -11,7 +11,7 @@ data class Arbeidsgiverperiode(
     companion object {
         // Periode 01.12.2021 - 30.06.2022
         val refusjonFraDato = LocalDate.of(2021, 12, 1)
-        val refusjonTilDato = LocalDate.of(2022, 6, 30)
+        val refusjonTilDato = LocalDate.of(2022, 7, 1)
         val arbeidsgiverBetalerForDager = 5
         val antallMånederTilStengt: Long = 3
 

--- a/src/main/kotlin/no/nav/helse/sporenstreks/web/dto/validation/CustomValiktorConstraints.kt
+++ b/src/main/kotlin/no/nav/helse/sporenstreks/web/dto/validation/CustomValiktorConstraints.kt
@@ -130,8 +130,8 @@ class RefusjonsdagerInnenforGjenaapningConstraint(override val messageParams: Ma
 
 fun <E> Validator<E>.Property<Iterable<Arbeidsgiverperiode>?>.refusjonsdatoIkkeEtterGjenåpning(refusjonsdagerTom: LocalDate) =
     this.validate(RefusjonsdagerInnenforGjenaapningConstraint(mapOf("dato" to dateFormatter.format(refusjonsdagerTom)))) { ps ->
-        ps!!.all { p ->
-            (p.fom < refusjonsdagerTom)
+        ps!!.any { p ->
+            p.fom.isBefore(refusjonsdagerTom)
         }
     }
 

--- a/src/test/kotlin/no/nav/helse/sporenstreks/web/dto/RefusjonsKravDtoTestIkkeEtterGjenåpning.kt
+++ b/src/test/kotlin/no/nav/helse/sporenstreks/web/dto/RefusjonsKravDtoTestIkkeEtterGjenåpning.kt
@@ -1,0 +1,79 @@
+package no.nav.helse.sporenstreks.web.dto
+
+import io.mockk.every
+import io.mockk.mockkStatic
+import no.nav.helse.TestData
+import no.nav.helse.sporenstreks.domene.Arbeidsgiverperiode
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.valiktor.ConstraintViolationException
+import org.valiktor.i18n.toMessage
+import java.time.LocalDate
+import kotlin.test.assertEquals
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class RefusjonsKravDtoTestIkkeEtterGjenåpning {
+    @BeforeAll
+    fun setup() {
+        mockkStatic(Class.forName("java.time.LocalDate").kotlin)
+        every { LocalDate.now() } returns LocalDate.parse("2022-07-15")
+    }
+
+    @Test
+    fun `Kan ikke søke refusjonskrav etter gjenåpning`() {
+        try {
+            RefusjonskravDto(
+                TestData.validIdentitetsnummer,
+                TestData.validOrgNr,
+                setOf(
+                    Arbeidsgiverperiode(
+                        LocalDate.of(2022, 7, 1),
+                        LocalDate.of(2022, 7, 10),
+                        2, 2.3
+                    )
+                )
+            ).validate(TestData.arbeidsForhold)
+        } catch (ex: ConstraintViolationException) {
+            val validationError = ex.constraintViolations
+                .map { "${it.constraint.name}: ${it.toMessage().message}" }
+                .first()
+            assertEquals("RefusjonsdagerInnenforGjenaapningConstraint: Det kan ikke kreves refusjon fra og med 01.07.2022", validationError)
+        }
+    }
+
+    @Test
+    fun `Kan søke refusjonskrav før gjenåpning`() {
+        RefusjonskravDto(
+            TestData.validIdentitetsnummer,
+            TestData.validOrgNr,
+            setOf(
+                Arbeidsgiverperiode(
+                    LocalDate.of(2022, 6, 30),
+                    LocalDate.of(2022, 7, 10),
+                    2, 2.3
+                )
+            )
+        ).validate(TestData.arbeidsForhold)
+    }
+
+    @Test
+    fun `Kan søke refusjonskrav hvis en periode er før gjenåpning`() {
+        RefusjonskravDto(
+            TestData.validIdentitetsnummer,
+            TestData.validOrgNr,
+            setOf(
+                Arbeidsgiverperiode(
+                    LocalDate.of(2022, 6, 30),
+                    LocalDate.of(2022, 7, 10),
+                    2, 2.3
+                ),
+                Arbeidsgiverperiode(
+                    LocalDate.of(2022, 7, 11),
+                    LocalDate.of(2022, 7, 13),
+                    2, 2.3
+                )
+            )
+        ).validate(TestData.arbeidsForhold)
+    }
+}


### PR DESCRIPTION
Sporenstreks skal avvikles. Ordningen med refusjon dag 6 på grunn av koronarelatert sykefravær gjelder fram til om med 30.06.2022.